### PR TITLE
Comment out dbEvent.h and dbAccess.h to avoid structure redefinition error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ addons:
     - re2c
 matrix:
     include:
+    - name: "7.0 master"
+      env: BASE=7.0  STATIC=shared
+
     - name: "3.16 master"
       env: BASE=3.16  STATIC=shared
     

--- a/caputRecorderApp/src/subMLIS.c
+++ b/caputRecorderApp/src/subMLIS.c
@@ -5,10 +5,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include <dbAccess.h>
+/*#include <dbAccess.h>*/
 #include <recGbl.h>
 #include <recSup.h>
-#include <dbEvent.h>
+/*#include <dbEvent.h>*/
 #include <subRecord.h>
 #include <registryFunction.h>
 #include <epicsExport.h>

--- a/caputRecorderApp/src/subMLIS.c
+++ b/caputRecorderApp/src/subMLIS.c
@@ -5,10 +5,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-/*#include <dbAccess.h>*/
 #include <recGbl.h>
 #include <recSup.h>
-/*#include <dbEvent.h>*/
 #include <subRecord.h>
 #include <registryFunction.h>
 #include <epicsExport.h>


### PR DESCRIPTION
On base 7.0.5 there is an error because the evSubscrip is locally defined, but it is also defined in dbChannel.h in base, which is included from dbEvent.h and dbAccess.h.  On 7.0.5 it is sufficient to comment out dbEvent.h and dbAccess.h.  We need to see if this breaks on older versions of base.