### PR TITLE
evSubscrip now defined in dbChannel

### DIFF
--- a/caputRecorderApp/src/subMLIS.c
+++ b/caputRecorderApp/src/subMLIS.c
@@ -23,6 +23,8 @@ epicsExportAddress(int, debugSubMLIS);
 	} evSub;
 #else
 	#include "dbChannel.h"
+	
+	typedef evSubscrip evSub;
 #endif
 
 long	initSubMLIS(struct subRecord *psub)

--- a/caputRecorderApp/src/subMLIS.c
+++ b/caputRecorderApp/src/subMLIS.c
@@ -10,15 +10,20 @@
 #include <subRecord.h>
 #include <registryFunction.h>
 #include <epicsExport.h>
+#include <epicsVersion.h>
 
 int	debugSubMLIS = 0;
 epicsExportAddress(int, debugSubMLIS);
 
 #define NUM_EVENT_SUBSCRIPTIONS 5
-typedef struct evSubscrip {
-    ELLNODE                 node;
-    struct dbAddr           *paddr;
-} evSub;
+
+#if EPICS_VERSION_INT < VERSION_INT(3, 15, 0, 1)
+	typedef struct evSubscrip {
+		ELLNODE                 node;
+	} evSub;
+#else
+	#include "dbChannel.h"
+#endif
 
 long	initSubMLIS(struct subRecord *psub)
 {


### PR DESCRIPTION
Encloses evSubscrip in a version check as base now defines that in dbChannel.h.

per #4 